### PR TITLE
Fix validation for empty check runs

### DIFF
--- a/internal/dtr/check.go
+++ b/internal/dtr/check.go
@@ -21,11 +21,17 @@
 package dtr
 
 import (
+	"fmt"
 	"io"
 )
 
 func Check(in io.Reader) (CheckResult, error) {
 	config, err := LoadConfig(in)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateCheckConfig(config.Source.Check)
 	if err != nil {
 		return nil, err
 	}
@@ -51,4 +57,11 @@ func Check(in io.Reader) (CheckResult, error) {
 	}
 
 	return result, nil
+}
+
+func validateCheckConfig(c Custom) error {
+	if c.Run == "" {
+		return fmt.Errorf("run command not specified. Bailing out")
+	}
+	return nil
 }

--- a/internal/dtr/in_test.go
+++ b/internal/dtr/in_test.go
@@ -59,4 +59,24 @@ var _ = Describe("In", func() {
 			}))
 		})
 	})
+
+	Context("empty/no-op configuration", func() {
+		It("should not fail", func() {
+			_, err := In(feed(Config{}))
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return given version", func() {
+			version := Version{"ref": "foobar"}
+			result, err := In(feed(Config{
+				Version: version,
+			}))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(InOutResult{
+				Version: version,
+			}))
+		})
+	})
 })


### PR DESCRIPTION
Fixes bug introduced by homeport/duct-tape-resource#31 that did not allow no/op In configuration Validates check config before running execute