### PR TITLE
Add support for OS args in `in`

### DIFF
--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -32,7 +32,7 @@ import (
 )
 
 func main() {
-	result, err := dtr.In(os.Stdin)
+	result, err := dtr.In(os.Stdin, os.Args[1:]...)
 	if err != nil {
 		fmt.Fprint(os.Stderr, neat.ContentBox(
 			"Failed to run in",

--- a/internal/dtr/in.go
+++ b/internal/dtr/in.go
@@ -24,13 +24,13 @@ import (
 	"io"
 )
 
-func In(in io.Reader) (InOutResult, error) {
+func In(in io.Reader, args ...string) (InOutResult, error) {
 	config, err := LoadConfig(in)
 	if err != nil {
 		return InOutResult{}, err
 	}
 
-	output, err := execute(config.Source.In)
+	output, err := execute(config.Source.In, args...)
 	if err != nil {
 		return InOutResult{}, err
 	}

--- a/internal/dtr/in_test.go
+++ b/internal/dtr/in_test.go
@@ -58,6 +58,25 @@ var _ = Describe("In", func() {
 				{Name: "bar", Value: "foo"},
 			}))
 		})
+
+		It("should have access to the OS arguments", func() {
+			version := Version{"ref": "foobar"}
+			result, err := In(
+				feed(Config{
+					Source: Source{
+						In: Custom{Run: "echo foo $1"},
+					},
+					Version: version,
+				}),
+				"bar",
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Version).To(Equal(version))
+			Expect(result.Metadata).To(Equal([]Metadata{
+				{Name: "foo", Value: "bar"},
+			}))
+		})
 	})
 
 	Context("empty/no-op configuration", func() {


### PR DESCRIPTION
Make sure to pipe through the OS args.
