### PR TITLE
Write version details into file

### DIFF
--- a/internal/dtr/dtr_suite_test.go
+++ b/internal/dtr/dtr_suite_test.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -41,4 +42,15 @@ func feed(config Config) io.Reader {
 	data, err := json.Marshal(config)
 	Expect(err).ToNot(HaveOccurred())
 	return bytes.NewReader(data)
+}
+
+func withTempDir(f func(dir string)) {
+	GinkgoHelper()
+
+	dir, err := os.MkdirTemp("", "dtr")
+	Expect(err).ToNot(HaveOccurred())
+
+	f(dir)
+
+	os.RemoveAll(dir)
 }

--- a/internal/dtr/in.go
+++ b/internal/dtr/in.go
@@ -22,12 +22,28 @@ package dtr
 
 import (
 	"io"
+	"os"
+	"path/filepath"
 )
 
 func In(in io.Reader, args ...string) (InOutResult, error) {
 	config, err := LoadConfig(in)
 	if err != nil {
 		return InOutResult{}, err
+	}
+
+	if len(args) > 0 {
+		// First argument should be a directory, but just to be on the safe side
+		// let's check that it's a directory and only then put the version details
+		// into a file in the input directory
+		var dir = args[0]
+		if fi, err := os.Stat(dir); err == nil && fi.IsDir() {
+			name := filepath.Join(dir, config.Source.ID)
+			data := []byte(config.Version[config.Source.ID])
+			if err := os.WriteFile(name, data, os.FileMode(0644)); err != nil {
+				return InOutResult{}, err
+			}
+		}
 	}
 
 	output, err := execute(config.Source.In, args...)

--- a/internal/dtr/in_test.go
+++ b/internal/dtr/in_test.go
@@ -21,6 +21,9 @@
 package dtr_test
 
 import (
+	"os"
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -76,6 +79,29 @@ var _ = Describe("In", func() {
 			Expect(result.Metadata).To(Equal([]Metadata{
 				{Name: "foo", Value: "bar"},
 			}))
+		})
+
+		It("should store the input version in a file", func() {
+			withTempDir(func(dir string) {
+				version := Version{"ref": "foobar"}
+				result, err := In(
+					feed(Config{
+						Source:  Source{In: Custom{Run: "true"}},
+						Version: version,
+					}),
+					dir,
+				)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Version).To(Equal(version))
+
+				refFile := filepath.Join(dir, "ref")
+				Expect(refFile).To(BeAnExistingFile())
+
+				data, err := os.ReadFile(refFile)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(data).To(Equal([]byte("foobar")))
+			})
 		})
 	})
 


### PR DESCRIPTION
When using the resource as an input, it's helpful to pass the
version details also in a file so that it can be used in a task.

Add code to write the version into a local file.
